### PR TITLE
Fix for fast moving sliders

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -249,14 +249,29 @@ class MultiSlider extends Component {
     let nextX = this._getValue(gestureState.dx);
 
     let compareFunc = (lhs,rhs,isGE) => { return isGE ? (lhs >= rhs) : (lhs > rhs)}
-    let compareTo = this.props.allowSameValues ? 0 : this.props.minSpace
+    let compareTo = this.props.allowSameValues ? 0 : this.props.minSpace;
+    let changeEvent = null;
 
-    if (currentThumb === 'left' && compareFunc((rightValue._value - nextX),compareTo,this.props.allowSameValues)) {
+    if (currentThumb === 'left') {
+      if(compareFunc((rightValue._value - nextX),compareTo,this.props.allowSameValues)) {
         leftValue.setValue(nextX);
-        this._fireChangeEvent('onLeftValueChange');
-    } else if (currentThumb === 'right' && compareFunc((nextX - leftValue._value),compareTo,this.props.allowSameValues)) {
+        changeEvent = 'onLeftValueChange';
+      } else if(this.props.allowSameValues) {
+        leftValue.setValue(rightValue._value);
+        changeEvent = 'onLeftValueChange';
+      }
+    } else if (currentThumb === 'right') {
+      if(compareFunc((nextX - leftValue._value),compareTo,this.props.allowSameValues)) {
         rightValue.setValue(nextX);
-        this._fireChangeEvent('onRightValueChange');
+        changeEvent = 'onRightValueChange';
+      } else if (this.props.allowSameValues) {
+        rightValue.setValue(leftValue._value);
+        changeEvent = 'onRightValueChange';
+      }
+    }
+
+    if(changeEvent != null) {
+      this._fireChangeEvent(changeEvent);
     }
 
   }

--- a/index.ios.js
+++ b/index.ios.js
@@ -15,7 +15,7 @@ class MultiSlider extends Component {
     this.state = {
       s1leftValue: 2000,
       s1rightValue: 2017,
-      s2leftValue: 2000,
+      s2leftValue: 1900,
       s2rightValue: 2017,
     };
   }
@@ -56,7 +56,7 @@ class MultiSlider extends Component {
               leftThumbColor = {'red'}
               rightThumbColor = {'blue'}
               rangeColor = {'pink'}
-              minValue = {2000}
+              minValue = {1900}
               maxValue = {2017}
               step = {1}
               allowSameValues = {true}


### PR DESCRIPTION
If you give a big range to the sliders (like I did in the example 1900-2017), it was hard to pull the knobs together, because the comparison function dropped the values if those were outside of the range. This pull request fixes it by snapping the knobs on "overpull". Thanks