### PR TITLE
Bundling error fixed: A trailing comma is not permitted after rest 

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -150,7 +150,7 @@ class MultiSlider extends Component {
       rightThumbColor,
       trackWidth,
       rangeColor,
-      ...other,
+      ...other
     } = this.props;
 
     let {


### PR DESCRIPTION
Removed comma so that it works with latest react native version (0.57 and above)

Fix of issue: https://github.com/santong/react-native-MultiSlider/issues/10